### PR TITLE
feat: cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 permissions:
   contents: write

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,17 +4,31 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: write
 
 env:
   DOCKER_BUILDKIT: 1
   CI_CONTAINER_IMAGE_NAME: docker.pkg.github.com/nmfr/cv/ci
 
 jobs:
-  pus-ci-container-image:
+  cd:
     runs-on: ubuntu-latest
+    concurrency: ci-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: docker login
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - run: make ci-container-build
       - run: make ci-container-push
+      - run: make ci-spell-check
+      - run: make prepare-gh-pages
+      - name: Deploy github pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: gh-pages

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
@@ -16,7 +13,7 @@ jobs:
   spell-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: docker login
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
       - run: make ci-container-build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-generated
+/generated

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ci-spell-check:
 	@mkdir -p generated
 	docker run -v ${PWD}/generated:/workspace/generated $(CI_CONTAINER_IMAGE_NAME) make spell-check
 
-# make prepare-gh-pages # Prepare the gh-pages folder to be deployed. This will copy the generated CV to the gh-pages folder making sure the HTML file is renamed to "index.html".
+# make prepare-gh-pages # Prepare the gh-pages folder to be deployed. This will copy the generated CV to the gh-pages folder making sure the HTML file is renamed to "index.html". Note that this command expects the contents of the `generated` folder to already be generated.
 .PHONY: prepare-gh-pages
 prepare-gh-pages:
 	mv generated/cv.html generated/index.html

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ spell-check: generate-html
 spell-check-readme:
 	hunspell -d en_US -l -H -p spell-check-exclude.dic README.md
 
-# make spell-check-format-exclude-file # Format the spell-check-exclude.dic file used to exclude spell checker errors. This will sort and remove duplicate lines from the file.
-.PHONY: spell-check-format-exclude-file
-spell-check-format-exclude-file:
+# make format-spell-check-exclude-file # Format the spell-check-exclude.dic file used to exclude spell checker errors. This will sort and remove duplicate lines from the file.
+.PHONY: format-spell-check-exclude-file
+format-spell-check-exclude-file:
 	SPELL_CHECK_FORMAT_RESULT=$$(cat spell-check-exclude.dic | egrep . | sort | uniq) && echo "$${SPELL_CHECK_FORMAT_RESULT}" > spell-check-exclude.dic
 
 .PHONY: ci-container-build
@@ -53,6 +53,15 @@ ci-container-build:
 ci-container-push:
 	docker push $(CI_CONTAINER_IMAGE_NAME) || true
 
+# The generated CV will be available in the "generated/" folder.
 .PHONY: ci-spell-check
 ci-spell-check:
-	docker run $(CI_CONTAINER_IMAGE_NAME) make spell-check
+	@rm -rf generated
+	@mkdir -p generated
+	docker run -v ${PWD}/generated:/workspace/generated $(CI_CONTAINER_IMAGE_NAME) make spell-check
+
+# make prepare-gh-pages # Prepare the gh-pages folder to be deployed. This will copy the generated CV to the gh-pages folder making sure the HTML file is renamed to "index.html".
+.PHONY: prepare-gh-pages
+prepare-gh-pages:
+	mv generated/cv.html generated/index.html
+	cp -rn generated/ gh-pages/

--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,4 @@ ci-spell-check:
 .PHONY: prepare-gh-pages
 prepare-gh-pages:
 	mv generated/cv.html generated/index.html
-	cp -rn generated/ gh-pages/
+	cp -rn generated/. gh-pages/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository generates the CV (Curriculum Vitae) present in https://cv.nunoro
 
 The CV contents are declared in the [`cv.json`](./cv.json) file.
 [jsonresume](https://jsonresume.org/) is used to generate the CV HTML from the [`cv.json`](./cv.json).
+Static assets to be added to the generated HTML should be placed in the ´gh-pages´ folder.
 [Github pages](https://pages.github.com/) is used to serve the CV HTML from the ´gh-pages´ branch on https://nmfr.github.io/cv.
 The [Github pages](https://pages.github.com/) is configured to use https://cv.nunorodrigues.tech/ as a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # CV
 
-Generate a CV (Curriculum Vitae) using [jsonresume](https://jsonresume.org/).
+This repository generates the CV (Curriculum Vitae) present in https://cv.nunorodrigues.tech/.
 
-The CV contents are present in the [`cv.json`](./cv.json) file.
+The CV contents are declared in the [`cv.json`](./cv.json) file.
+[jsonresume](https://jsonresume.org/) is used to generate the CV HTML from the [`cv.json`](./cv.json).
+[Github pages](https://pages.github.com/) is used to serve the CV HTML from the ´gh-pages´ branch on https://nmfr.github.io/cv.
+The [Github pages](https://pages.github.com/) is configured to use https://cv.nunorodrigues.tech/ as a [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages).
 
 ## Getting started
+
+[VS Code](https://code.visualstudio.com/) using the [development container](https://code.visualstudio.com/docs/remote/containers) is the recommended IDE.
 
 From within the [container](./Dockerfile) the following commands can be run:
 
@@ -53,7 +58,7 @@ The file uses the format defined [here](https://man.archlinux.org/man/hunspell.5
 
 ## Continuous delivery
 
-Every push to ´master´ will trigger the [CD github workflow](.github/workflows/cd.yaml) to: 
+Every push to ´master´ will trigger the [CD github workflow](.github/workflows/cd.yaml) to:
 - Generate the CV in HTML format.
 - Copy the generated assets to the ´gh-pages´ folder.
 - Push the contents of the ´gh-pages´ folder to the ´gh-pages´ branch root.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ From within the [container](./Dockerfile) the following commands can be run:
 -   Format the [`spell-check-exclude.dic`](./spell-check-exclude.dic) dictionary file used to exclude spell checker errors:
 
     ```sh
-    make spell-check-format-exclude-file
+    make format-spell-check-exclude-file
     ```
 
     This will sort and remove duplicate lines from the file.
@@ -50,3 +50,15 @@ To fix this, the CV HTML file is formatted to XHTML with [tidy](https://linux.di
 The [`spell-check-exclude.dic`](./spell-check-exclude.dic) dictionary file is used to exclude spell checker errors.
 If [Hunspell](http://hunspell.github.io/) is reporting false spelling errors, add the words to this file to fix the errors.
 The file uses the format defined [here](https://man.archlinux.org/man/hunspell.5.en).
+
+## Continuous delivery
+
+Every push to ´master´ will trigger the [CD github workflow](.github/workflows/cd.yaml) to: 
+- Generate the CV in HTML format.
+- Copy the generated assets to the ´gh-pages´ folder.
+- Push the contents of the ´gh-pages´ folder to the ´gh-pages´ branch root.
+
+The ´gh-pages´ branch uses [Github pages](https://pages.github.com/) to expose the branch's content in https://nmfr.github.io/cv.
+The content is also available in https://cv.nunorodrigues.tech/ as a [Github pages](https://pages.github.com/) custom domain.
+
+Any additional static assets that should be exposed together with the CV should be placed in the ´gh-pages´ folder.

--- a/gh-pages/CNAME
+++ b/gh-pages/CNAME
@@ -1,0 +1,1 @@
+cv.nunorodrigues.tech


### PR DESCRIPTION
Add CD to automatically deploy the generated HTML CV to the `gh-pages branch.
The `gh-pages branch is configured as a [Github pages](https://pages.github.com/) available at https://cv.nunorodrigues.tech/.